### PR TITLE
[WIP] Region Proposal Network (RPN) classification and regression losses

### DIFF
--- a/keras_rcnn/backend/common.py
+++ b/keras_rcnn/backend/common.py
@@ -4,25 +4,6 @@ import numpy
 import keras_rcnn.backend
 
 
-def anchor(base_size=16, ratios=None, scales=None):
-    """
-    Generates a regular grid of multi-aspect and multi-scale anchor boxes.
-    """
-    if ratios is None:
-        ratios = keras.backend.cast([0.5, 1, 2], 'float32')
-
-    if scales is None:
-        scales = keras.backend.cast([8, 16, 32], 'float32')
-    base_anchor = keras.backend.cast([1, 1, base_size, base_size],
-                                     'float32') - 1
-    base_anchor = keras.backend.expand_dims(base_anchor, 0)
-
-    ratio_anchors = _ratio_enum(base_anchor, ratios)
-    anchors = _scale_enum(ratio_anchors, scales)
-
-    return anchors
-
-
 def bbox_transform(ex_rois, gt_rois):
     ex_widths = ex_rois[:, 2] - ex_rois[:, 0] + 1.0
     ex_heights = ex_rois[:, 3] - ex_rois[:, 1] + 1.0
@@ -48,8 +29,6 @@ def bbox_transform(ex_rois, gt_rois):
 
 
 def clip(boxes, shape):
-    boxes = keras.backend.cast(boxes, dtype='int32')
-    shape = keras.backend.cast(shape, dtype='int32')
     proposals = [
         keras.backend.maximum(
             keras.backend.minimum(boxes[:, 0::4], shape[1] - 1), 0),
@@ -64,75 +43,22 @@ def clip(boxes, shape):
     return keras.backend.concatenate(proposals, axis=1)
 
 
-def _mkanchors(ws, hs, x_ctr, y_ctr):
-    """
-    Given a vector of widths (ws) and heights (hs) around a center
-    (x_ctr, y_ctr), output a set of anchors (windows).
-    """
-
-    col1 = keras.backend.reshape(x_ctr - 0.5 * (ws - 1), (-1, 1))
-    col2 = keras.backend.reshape(y_ctr - 0.5 * (hs - 1), (-1, 1))
-    col3 = keras.backend.reshape(x_ctr + 0.5 * (ws - 1), (-1, 1))
-    col4 = keras.backend.reshape(y_ctr + 0.5 * (hs - 1), (-1, 1))
-    anchors = keras.backend.concatenate((col1, col2, col3, col4), axis=1)
-
-    return anchors
-
-
-def _ratio_enum(anchor, ratios):
-    """
-    Enumerate a set of anchors for each aspect ratio wrt an anchor.
-    """
-    # import pdb
-    # pdb.set_trace()
-    w, h, x_ctr, y_ctr = _whctrs(anchor)
-    size = w * h
-    size_ratios = size / ratios
-    ws = keras.backend.round(keras.backend.sqrt(size_ratios))
-    hs = keras.backend.round(ws * ratios)
-    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
-    return anchors
-
-
-def _scale_enum(anchor, scales):
-    """
-    Enumerate a set of anchors for each scale wrt an anchor.
-    """
-
-    w, h, x_ctr, y_ctr = _whctrs(anchor)
-    ws = keras.backend.expand_dims(w, 1) * scales
-    hs = keras.backend.expand_dims(h, 1) * scales
-    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
-    return anchors
-
-
-def _whctrs(anchor):
-    """
-    Return width, height, x center, and y center for an anchor (window).
-    """
-    w = anchor[:, 2] - anchor[:, 0] + 1
-    h = anchor[:, 3] - anchor[:, 1] + 1
-    x_ctr = anchor[:, 0] + 0.5 * (w - 1)
-    y_ctr = anchor[:, 1] + 0.5 * (h - 1)
-    return w, h, x_ctr, y_ctr
-
-
-def shift(shape, stride):
+def shift(shape, anchors, stride):
     shift_x = keras.backend.arange(0, shape[0]) * stride
     shift_y = keras.backend.arange(0, shape[1]) * stride
 
     shift_x, shift_y = keras_rcnn.backend.meshgrid(shift_x, shift_y)
+    shift_x = keras.backend.reshape(shift_x, [-1])
+    shift_y = keras.backend.reshape(shift_y, [-1])
 
     shifts = keras.backend.stack([
-        keras.backend.reshape(shift_x, [-1]),
-        keras.backend.reshape(shift_y, [-1]),
-        keras.backend.reshape(shift_x, [-1]),
-        keras.backend.reshape(shift_y, [-1])
+        shift_x,
+        shift_y,
+        shift_x,
+        shift_y,
     ], axis=0)
 
     shifts = keras.backend.transpose(shifts)
-
-    anchors = keras_rcnn.backend.anchor()
 
     number_of_anchors = keras.backend.shape(anchors)[0]
 
@@ -174,31 +100,31 @@ def filter_boxes(proposals, minimum):
     ws = proposals[:, 2] - proposals[:, 0] + 1
     hs = proposals[:, 3] - proposals[:, 1] + 1
 
-    indicies = keras_rcnn.backend.where((ws >= minimum) & (hs >= minimum))
+    indices = keras_rcnn.backend.where((ws >= minimum) & (hs >= minimum))
 
-    indicies = keras.backend.flatten(indicies)
+    indices = keras.backend.flatten(indices)
 
-    return keras.backend.cast(indicies, "int32")
+    return keras.backend.cast(indices, "int32")
 
 
 def inside_image(y_pred, img_info):
     """
-    Calc indicies of anchors which are located completely inside of the image
+    Calc indices of boxes which are located completely inside of the image
     whose size is specified by img_info ((height, width, scale)-shaped array).
 
-    :param y_pred: anchors
+    :param boxes: bounding boxes
     :param img_info:
     :return:
     """
-    indicies = keras_rcnn.backend.where(
-        (y_pred[:, 0] >= 0) &
-        (y_pred[:, 1] >= 0) &
-        (y_pred[:, 2] < img_info[1]) &  # width
-        (y_pred[:, 3] < img_info[0])  # height
+    indices = keras_rcnn.backend.where(
+        (boxes[:, 0] >= 0) &
+        (boxes[:, 1] >= 0) &
+        (boxes[:, 2] < img_info[1]) &  # width
+        (boxes[:, 3] < img_info[0])  # height
     )
 
-    indicies = keras.backend.cast(indicies, "int32")
+    indices = keras.backend.cast(indices, "int32")
 
-    gathered = keras.backend.gather(y_pred, indicies)
+    gathered = keras.backend.gather(boxes, indices)
 
-    return indicies[:, 0], keras.backend.reshape(gathered, [-1, 4])
+    return indices[:, 0], keras.backend.reshape(gathered, [-1, 4])

--- a/keras_rcnn/classifiers/resnet.py
+++ b/keras_rcnn/classifiers/resnet.py
@@ -3,29 +3,18 @@ import keras.layers
 import keras_resnet.blocks
 
 
-def residual(classes, mask=False):
+def residual(classes, mask=False, features=512):
     """Resnet classifiers as in Mask R-CNN."""
     def f(x):
-        if keras.backend.image_data_format() == "channels_last":
-            channel_axis = 3
-        else:
-            channel_axis = 1
-
-        y = keras.layers.TimeDistributed(keras.layers.Conv2D(1024, (1, 1)))(x)
-
         # conv5 block as in Deep Residual Networks with first conv operates
         # on a 7x7 RoI with stride 1 (instead of 14x14 / stride 2)
-        for i in range(3):
-            y = keras_resnet.blocks.time_distributed_bottleneck_2d(512, (1, 1), first=True)(y)
-
-        y = keras.layers.TimeDistributed(keras.layers.BatchNormalization(axis=channel_axis))(y)
-        y = keras.layers.TimeDistributed(keras.layers.Activation("relu"))(y)
+        y = keras_resnet.blocks.time_distributed_bottleneck_2d(features, stage=3, block=0, stride=1)(x)
+        y = keras_resnet.blocks.time_distributed_bottleneck_2d(features, stage=3, block=1, stride=1)(y)
+        y = keras_resnet.blocks.time_distributed_bottleneck_2d(features, stage=3, block=2, stride=1)(y)
 
         # class and box branches
-        y = keras.layers.TimeDistributed(keras.layers.AveragePooling2D((7, 7)))(y)
-
+        y = keras.layers.TimeDistributed(keras.layers.GlobalAveragePooling2D())(y)
         score = keras.layers.TimeDistributed(keras.layers.Dense(classes, activation="softmax"))(y)
-
         boxes = keras.layers.TimeDistributed(keras.layers.Dense(4 * classes))(y)
 
         # TODO{JihongJu} the mask branch

--- a/keras_rcnn/classifiers/resnet.py
+++ b/keras_rcnn/classifiers/resnet.py
@@ -1,6 +1,6 @@
 import keras.backend
 import keras.layers
-import keras_resnet.block.temporal
+import keras_resnet.blocks
 
 
 def residual(classes, mask=False):
@@ -16,7 +16,7 @@ def residual(classes, mask=False):
         # conv5 block as in Deep Residual Networks with first conv operates
         # on a 7x7 RoI with stride 1 (instead of 14x14 / stride 2)
         for i in range(3):
-            y = keras_resnet.block.temporal.bottleneck(512, (1, 1), first=True)(y)
+            y = keras_resnet.blocks.time_distributed_bottleneck_2d(512, (1, 1), first=True)(y)
 
         y = keras.layers.TimeDistributed(keras.layers.BatchNormalization(axis=channel_axis))(y)
         y = keras.layers.TimeDistributed(keras.layers.Activation("relu"))(y)

--- a/keras_rcnn/layers/object_detection/_object_proposal.py
+++ b/keras_rcnn/layers/object_detection/_object_proposal.py
@@ -4,11 +4,12 @@ import tensorflow
 
 import keras_rcnn.backend
 
-
 class ObjectProposal(keras.engine.topology.Layer):
-    def __init__(self, maximum_proposals=300, **kwargs):
-        self.output_dim = (None, maximum_proposals, 4)
-
+    def __init__(
+        self,
+        maximum_proposals=300,
+        **kwargs
+    ):
         self.maximum_proposals = maximum_proposals
 
         super(ObjectProposal, self).__init__(**kwargs)
@@ -17,36 +18,55 @@ class ObjectProposal(keras.engine.topology.Layer):
         super(ObjectProposal, self).build(input_shape)
 
     def call(self, inputs, **kwargs):
-        return self.propose(inputs[0], inputs[1], self.maximum_proposals)
+        boxes, scores, anchors, im_info = inputs
+        return self.propose(boxes, scores, anchors, im_info)
 
     def compute_output_shape(self, input_shape):
-        return self.output_dim
+        return [(input_shape[0], self.maximum_proposals, 4), (input_shape[0], self.maximum_proposals)]
 
-    @staticmethod
-    def propose(boxes, scores, maximum):
+    def propose(self, boxes, scores, anchors, im_info):
+        # 1. Generate proposals from bbox deltas and shifted anchors
         shape = keras.backend.shape(boxes)[1:3]
 
-        shifted = keras_rcnn.backend.shift(shape, 16)
+        # shift the anchors to original image shape
+        shifted = keras_rcnn.backend.shift(shape, anchors, 16)
+        shifted = keras.backend.reshape(shifted, (-1, 1, 4))
 
-        proposals = keras.backend.reshape(boxes, (-1, 4))
+        # apply shifts to anchors
+        anchors = keras.backend.reshape(anchors, (1, -1, 4))
+        anchors = keras.backend.reshape(anchors + shifted, (-1, 4))
 
-        proposals = keras_rcnn.backend.bbox_transform_inv(shifted, proposals)
-
-        proposals = keras_rcnn.backend.clip(proposals, shape)
-
-        indicies = keras_rcnn.backend.filter_boxes(proposals, 1)
-
-        proposals = keras.backend.gather(proposals, indicies)
-        scores = scores[:, :, :, :9]
+        # reshape predicted bbox to get them into the same order as the anchor
+        boxes  = keras.backend.reshape(boxes, (-1, 4))
         scores = keras.backend.reshape(scores, (-1, 1))
-        scores = keras.backend.gather(scores, indicies)
-        scores = keras.backend.flatten(scores)
 
-        proposals = keras.backend.cast(proposals, keras.backend.floatx())
-        scores = keras.backend.cast(scores, keras.backend.floatx())
+        # convert anchors into proposals via bbox transformations
+        proposals = keras_rcnn.backend.bbox_transform_inv(anchors, boxes)
 
-        indicies = keras_rcnn.backend.non_maximum_suppression(proposals, scores, maximum, 0.7)
+        # 2. Clip predicted boxes to image
+        proposals = keras_rcnn.backend.clip(proposals, im_info[:2])
 
-        proposals = keras.backend.gather(proposals, indicies)
+        # 3. Remove predicted boxes with either height or width < threshold
+        indices   = keras_rcnn.backend.filter_boxes(proposals, 16.0 * im_info[2])
+        proposals = keras.backend.gather(proposals, indices)
+        scores    = keras.backend.gather(scores, indices)
 
-        return keras.backend.expand_dims(proposals, 0)
+        # 4. sort all (proposal, score) pairs by score from highest to lowest
+        # 5. take top pre_nms_topN (e.g. 6000)
+        # TODO ?
+
+        # 6. apply nms (e.g. threshold = 0.7)
+        # 7. take after_nms_topN (e.g. 300) (#TODO)
+        # 8. return the top proposals (-> RoIs top) (#TODO)
+        indices   = keras_rcnn.backend.non_maximum_suppression(proposals, scores, self.maximum_proposals, 0.7)
+        proposals = keras.backend.gather(proposals, indices)
+        scores    = keras.backend.gather(scores, indices)
+
+        # These would have to be filled with the proposal labels and target proposals
+        #labels          = keras.backend.placeholder((1,))
+        #targets         = keras.backend.placeholder((1,))
+        #inside_weights  = keras.backend.placeholder((1,))
+        #outside_weights = keras.backend.placeholder((1,))
+
+        return [keras.backend.expand_dims(proposals, 0), scores]
+

--- a/keras_rcnn/layers/object_detection/generate_anchors.py
+++ b/keras_rcnn/layers/object_detection/generate_anchors.py
@@ -1,0 +1,97 @@
+# --------------------------------------------------------
+# Faster R-CNN
+# Copyright (c) 2015 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by Ross Girshick and Sean Bell
+# --------------------------------------------------------
+
+import numpy as np
+
+# Verify that we compute the same anchors as Shaoqing's matlab implementation:
+#
+#    >> load output/rpn_cachedir/faster_rcnn_VOC2007_ZF_stage1_rpn/anchors.mat
+#    >> anchors
+#
+#    anchors =
+#
+#       -83   -39   100    56
+#      -175   -87   192   104
+#      -359  -183   376   200
+#       -55   -55    72    72
+#      -119  -119   136   136
+#      -247  -247   264   264
+#       -35   -79    52    96
+#       -79  -167    96   184
+#      -167  -343   184   360
+
+#array([[ -83.,  -39.,  100.,   56.],
+#       [-175.,  -87.,  192.,  104.],
+#       [-359., -183.,  376.,  200.],
+#       [ -55.,  -55.,   72.,   72.],
+#       [-119., -119.,  136.,  136.],
+#       [-247., -247.,  264.,  264.],
+#       [ -35.,  -79.,   52.,   96.],
+#       [ -79., -167.,   96.,  184.],
+#       [-167., -343.,  184.,  360.]])
+
+def generate_anchors(base_size=16, ratios=[0.5, 1, 2],
+                     scales=2**np.arange(3, 6)):
+    """
+    Generate anchor (reference) windows by enumerating aspect ratios X
+    scales wrt a reference (0, 0, 15, 15) window.
+    """
+
+    base_anchor   = np.array([1, 1, base_size, base_size]) - 1
+    ratio_anchors = _ratio_enum(base_anchor, ratios)
+    anchors       = np.vstack([_scale_enum(ratio_anchors[i, :], scales)
+                         for i in range(ratio_anchors.shape[0])])
+    return anchors
+
+def _whctrs(anchor):
+    """
+    Return width, height, x center, and y center for an anchor (window).
+    """
+
+    w = anchor[2] - anchor[0] + 1
+    h = anchor[3] - anchor[1] + 1
+    x_ctr = anchor[0] + 0.5 * (w - 1)
+    y_ctr = anchor[1] + 0.5 * (h - 1)
+    return w, h, x_ctr, y_ctr
+
+def _mkanchors(ws, hs, x_ctr, y_ctr):
+    """
+    Given a vector of widths (ws) and heights (hs) around a center
+    (x_ctr, y_ctr), output a set of anchors (windows).
+    """
+
+    ws = ws[:, np.newaxis]
+    hs = hs[:, np.newaxis]
+    anchors = np.hstack((x_ctr - 0.5 * (ws - 1),
+                         y_ctr - 0.5 * (hs - 1),
+                         x_ctr + 0.5 * (ws - 1),
+                         y_ctr + 0.5 * (hs - 1)))
+    return anchors
+
+def _ratio_enum(anchor, ratios):
+    """
+    Enumerate a set of anchors for each aspect ratio wrt an anchor.
+    """
+
+    w, h, x_ctr, y_ctr = _whctrs(anchor)
+    size = w * h
+    size_ratios = size / ratios
+    ws = np.round(np.sqrt(size_ratios))
+    hs = np.round(ws * ratios)
+    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
+    return anchors
+
+def _scale_enum(anchor, scales):
+    """
+    Enumerate a set of anchors for each scale wrt an anchor.
+    """
+
+    w, h, x_ctr, y_ctr = _whctrs(anchor)
+    ws = w * scales
+    hs = h * scales
+    anchors = _mkanchors(ws, hs, x_ctr, y_ctr)
+    return anchors

--- a/keras_rcnn/losses/rpn.py
+++ b/keras_rcnn/losses/rpn.py
@@ -1,161 +1,46 @@
-import keras.backend
+import keras.backend as K
 import keras.losses
-import tensorflow
+import tensorflow as tf
 
 import keras_rcnn.backend
 
 
-def separate_pred(y_pred):
-    anchors = keras.backend.shape(y_pred)[-1] // 5
-    return y_pred[:, :, :, 0: 4 * anchors], y_pred[:, :, :, 4 * anchors: 5 * anchors]
+class RpnLossCls(Layer):
+    def call(self, inputs):
+        rpn_labels, rpn_cls_score = inputs
+        self.add_loss(K.mean(K.categorical_crossentropy(rpn_labels_reshape, rpn_labels_reshape)), inputs=inputs)
+        return rpn_labels
 
+class RpnLossBbox(Layer):
+    def __init__(self, **kwargs):
+        self.is_placeholder = True
+        super().__init__(**kwargs)
 
-def encode(features, image_shape, y_true, stride=16):
-    # get all anchors inside bbox
-    shifted_anchors = keras_rcnn.backend.shift(features, stride)
-    inds_inside, all_inside_bbox = keras_rcnn.backend.inside_image(shifted_anchors, image_shape)
+    def smooth_l1(self, bbox_pred, bbox_targets, bbox_inside_weights, bbox_outside_weights, sigma=3.0):
+        """
+            ResultLoss = outside_weights * SmoothL1(inside_weights * (bbox_pred - bbox_targets))
+            SmoothL1(x) = 0.5 * (sigma * x)^2,    if |x| < 1 / sigma^2
+                          |x| - 0.5 / sigma^2,    otherwise
+        """
+        sigma2 = sigma**2
 
-    # indices of gt boxes with the greatest overlap, bbox labels
-    # TODO: assert y_true.shape[0] == 1
-    y_true = y_true[0, :, :]
-    argmax_overlaps_inds, bbox_labels = keras_rcnn.backend.label(y_true, all_inside_bbox, inds_inside)
+        inside_mul = tf.multiply(bbox_inside_weights, tf.subtract(bbox_pred, bbox_targets))
 
-    # gt boxes
-    gt_boxes = keras.backend.gather(y_true, argmax_overlaps_inds)
+        smooth_l1_sign    = tf.cast(tf.less(tf.abs(inside_mul), 1.0 / sigma2), tf.float32)
+        smooth_l1_option1 = tf.multiply(tf.multiply(inside_mul, inside_mul), 0.5 * sigma2)
+        smooth_l1_option2 = tf.subtract(tf.abs(inside_mul), 0.5 / sigma2)
+        smooth_l1_result  = tf.add(tf.multiply(smooth_l1_option1, smooth_l1_sign),
+            tf.multiply(smooth_l1_option2, tf.abs(tf.subtract(smooth_l1_sign, 1.0))))
 
-    # Convert fixed anchors in (x, y, w, h) to (dx, dy, dw, dh)
-    bbox_reg_targets = keras_rcnn.backend.bbox_transform(all_inside_bbox, gt_boxes)
+        outside_mul = tf.multiply(bbox_outside_weights, smooth_l1_result)
 
-    return bbox_labels, bbox_reg_targets, inds_inside
+        return outside_mul
 
+    def call(self, inputs):
+        rpn_bbox_pred, rpn_bbox_targets, rpn_bbox_inside_weights, rpn_bbox_outside_weights = inputs
 
-def proposal(anchors, image_shape, stride, *args, **kwargs):
-    def f(y_true, y_pred):
-        # separate y_pred into rpn_cls_pred and rpn_reg_pred
-        y_pred_regression, y_pred_classification = separate_pred(y_pred)
+        rpn_smooth_l1 = self.smooth_l1(rpn_bbox_pred, rpn_bbox_targets, rpn_bbox_inside_weights, rpn_bbox_outside_weights)
+        loss          = tf.reduce_mean(tf.reduce_sum(rpn_smooth_l1, axis=[1, 2, 3]))
 
-        # convert y_true from gt_boxes to gt_anchors
-        features = y_pred.get_shape().as_list()[1:3]
-
-        gt_classification, gt_regression, inds_inside = encode(features, image_shape, y_true, stride)
-
-        y_true_classification = keras.backend.zeros((1, features[0], features[1], anchors * 2))
-
-        y_true_regression = keras.backend.zeros((1, features[0], features[1], anchors * 8))
-
-        z = keras.backend.expand_dims(keras.backend.zeros_like(inds_inside), 1)
-
-        i = keras.backend.expand_dims(inds_inside // (anchors * features[1]), 1)
-
-        j = keras.backend.expand_dims(inds_inside // anchors % features[1], 1)
-
-        a = keras.backend.expand_dims((inds_inside % anchors), 1)
-
-        zz = keras.backend.tile(z, [4, 1])
-
-        ii = keras.backend.tile(i, [4, 1])
-
-        jj = keras.backend.tile(j, [4, 1])
-
-        aa = keras.backend.concatenate([4 * a, 4 * a + 1, 4 * a + 2, 4 * a + 3], 0)
-
-        gt_r1 = keras.backend.tile(gt_classification, [4])
-
-        gt_r1_mask = keras.backend.equal(keras.backend.abs(gt_r1), 1.0)
-
-        gt_r1_mask = keras.backend.cast(gt_r1_mask, keras.backend.floatx())
-
-        gt_c1_mask = keras.backend.equal(keras.backend.abs(gt_classification), 1.0)
-
-        gt_c1_mask = keras.backend.cast(gt_c1_mask, keras.backend.floatx())
-
-        gt_c2_mask = keras.backend.equal(keras.backend.abs(gt_classification), 1.0)
-
-        gt_c2_mask = keras.backend.cast(gt_c2_mask, keras.backend.floatx())
-
-        y_true_classification_indicies = keras.backend.concatenate([z, i, j, a], 1)
-
-        y_true_classification = keras_rcnn.backend.scatter_add_tensor(y_true_classification, y_true_classification_indicies, gt_c1_mask)
-
-        y_true_classification_indicies = keras.backend.concatenate([z, i, j, anchors + a], 1)
-
-        y_true_classification = keras_rcnn.backend.scatter_add_tensor(y_true_classification, y_true_classification_indicies, gt_c2_mask)
-
-        y_true_regression_indicies = keras.backend.concatenate([zz, ii, jj, aa], 1)
-
-        y_true_regression = keras_rcnn.backend.scatter_add_tensor(y_true_regression, y_true_regression_indicies, gt_r1_mask)
-
-        y_true_regression_indicies = keras.backend.concatenate([zz, ii, jj, anchors * 4 + aa], 1)
-
-        y_true_regression_updates = keras.backend.reshape(gt_regression, (-1,))
-
-        y_true_regression = keras_rcnn.backend.scatter_add_tensor(y_true_regression, y_true_regression_indicies, y_true_regression_updates)
-
-        y_true_classification = keras.backend.reshape(y_true_classification, (1, features[0], features[1], anchors * 2))
-
-        y_true_regression = keras.backend.reshape(y_true_regression, (1, features[0], features[1], anchors * 8))
-
-        classification = _classification(anchors=anchors)(y_true_classification, y_pred_classification)
-
-        regression = _regression(anchors=anchors)(y_true_regression, y_pred_regression)
-
-        return classification, regression
-
-    return f
-
-
-def _classification(anchors=9):
-    """
-    Return the classification loss of region proposal network.
-
-    :param anchors: Integer, number of anchors at each sliding position. Equal to number of scales * number of aspect ratios.
-
-    :return: A loss function for region propose classification.
-    """
-
-    def f(y_true, y_pred):
-        # Binary classification loss
-        x, y = y_pred[:, :, :, :], y_true[:, :, :, anchors:]
-
-        a = y_true[:, :, :, :anchors] * keras.backend.binary_crossentropy(x, y)
-        a = keras.backend.sum(a)
-
-        # Divided by anchor overlaps
-        b = keras.backend.epsilon() + y_true[:, :, :, :anchors]
-        b = keras.backend.sum(b)
-
-        return 1.0 * (a / b)
-
-    return f
-
-
-def _regression(anchors=9):
-    """
-    Return the regression loss of region proposal network.
-
-    :param anchors: Integer, number of anchors at each sliding position. Equal to number of scales * number of aspect ratios.
-
-    :return: A loss function region propose regression.
-    """
-
-    def f(y_true, y_pred):
-        # Robust L1 Loss
-        x = y_true[:, :, :, 4 * anchors:] - y_pred
-
-        mask = keras.backend.less_equal(keras.backend.abs(x), 1.0)
-        mask = keras.backend.cast(mask, keras.backend.floatx())
-
-        a_x = y_true[:, :, :, :4 * anchors]
-
-        a_y = mask * (0.5 * x * x) + (1 - mask) * (keras.backend.abs(x) - 0.5)
-
-        a = a_x * a_y
-        a = keras.backend.sum(a)
-
-        # Divided by anchor overlaps
-        b = keras.backend.epsilon() + a_x
-        b = keras.backend.sum(b)
-
-        return 1.0 * (a / b)
-
-    return f
+        self.add_loss(loss, inputs=inputs)
+        return rpn_bbox_pred

--- a/keras_rcnn/models.py
+++ b/keras_rcnn/models.py
@@ -5,6 +5,11 @@ import keras_resnet.models
 
 import keras_rcnn.layers
 import keras_rcnn.classifiers
+import keras_rcnn.losses
+
+from keras_rcnn.layers.object_detection.generate_anchors import generate_anchors
+
+import numpy as np
 
 
 class RCNN(keras.models.Model):
@@ -12,34 +17,45 @@ class RCNN(keras.models.Model):
     Faster R-CNN model by S Ren et, al. (2015).
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
-    :param encoder: (Convolutional) feature extractor, e.g., `keras_resnet.models.ResNet50`
     :param heads: R-CNN classifiers for object detection and/or segmentation on the proposed regions
     :param rois: integer, number of regions of interest per image
+    :param anchor_ratios: list of anchor ratios to generate
+    :param anchor_scales: list of anchor scales to generate
 
     :return model: a functional model API for R-CNN.
     """
 
-    def __init__(self, inputs, encoder, heads, rois):
-        # Extract features with the encoder
-        y = encoder(inputs)
+    def __init__(self, inputs, features, heads, rois, anchor_ratios=[0.5, 1, 2], anchor_scales=[8, 16, 32]):
+        data, im_info, gt_boxes = inputs
 
-        features = y.layers[-2].output
+        num_anchors   = len(anchor_ratios) * len(anchor_scales)
+        anchor_ratios = np.array(anchor_ratios, dtype=keras.backend.floatx())
+        anchor_scales = np.array(anchor_scales, dtype=keras.backend.floatx())
 
-        # Propose regions given the features
-        rpn_classification = keras.layers.Conv2D(9 * 1, (1, 1), activation="sigmoid")(features)
+        #TODO Figure out a way around using a lambda layer here
+        anchors       = keras.layers.Lambda(lambda x: keras.backend.constant(generate_anchors(ratios=anchor_ratios, scales=anchor_scales), dtype=keras.backend.floatx()))(data)
 
-        rpn_regression = keras.layers.Conv2D(9 * 4, (1, 1))(features)
+        # Append RPN
+        rpn_conv      = keras.layers.Conv2D(512            , kernel_size=(3, 3), padding="same", activation="relu", name="rpn_conv")(features)
+        rpn_cls_prob  = keras.layers.Conv2D(num_anchors * 2, kernel_size=(1, 1), activation="sigmoid", name="rpn_cls_prob")(rpn_conv)
+        rpn_bbox_pred = keras.layers.Conv2D(num_anchors * 4, kernel_size=(1, 1), name="rpn_bbox_pred")(rpn_conv)
 
-        rpn_prediction = keras.layers.concatenate([rpn_classification, rpn_regression])
+        # Generate object proposals
+        proposals, scores = keras_rcnn.layers.object_detection.ObjectProposal(
+            maximum_proposals=rois,
+            name="rpn_proposals",
+        )([rpn_bbox_pred, rpn_cls_prob, anchors, im_info])
 
-        proposals = keras_rcnn.layers.object_detection.ObjectProposal(rois)([rpn_regression, rpn_classification])
+        # Add RPN losses
+        #rpn_cls_loss  = keras_rcnn.losses.RpnLossCls()([rpn_labels, rpn_cls_prob])
+        #rpn_bbox_loss = keras_rcnn.losses.RpnLossBbox()([proposals, targets, inside_weights, outside_weights])
 
         # Apply the classifiers on the proposed regions
-        slices = keras_rcnn.layers.ROI((7, 7))([inputs, proposals])
+        slices = keras_rcnn.layers.ROI((7, 7))([data, proposals])
 
         [score, boxes] = heads(slices)
 
-        super(RCNN, self).__init__(inputs, [rpn_prediction, score, boxes])
+        super(RCNN, self).__init__(inputs, [score, boxes])
 
 
 class ResNet50RCNN(RCNN):
@@ -49,15 +65,19 @@ class ResNet50RCNN(RCNN):
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
     :param classes: integer, number of classes
     :param rois: integer, number of regions of interest per image
+    :param blocks: list of blocks to use in ResNet50
+    :param anchor_ratios: list of anchor ratios to generate
+    :param anchor_scales: list of anchor scales to generate
 
     :return model: a functional model API for R-CNN.
     """
 
-    def __init__(self, inputs, classes, rois=300):
+    def __init__(self, inputs, classes, rois=300, blocks=[3, 4, 6], anchor_ratios=[0.5, 1, 2], anchor_scales=[8, 16, 32]):
         # ResNet50 as encoder
-        encoder = keras_resnet.models.ResNet50
+        data, _, _ = inputs
+        features = keras_resnet.models.ResNet50(data, blocks=blocks, include_top=False).output
 
         # ResHead with score and boxes
         heads = keras_rcnn.classifiers.residual(classes)
 
-        super(ResNet50RCNN, self).__init__(inputs, encoder, heads, rois)
+        super(ResNet50RCNN, self).__init__(inputs, features, heads, rois, anchor_ratios=anchor_ratios, anchor_scales=anchor_scales)

--- a/keras_rcnn/models.py
+++ b/keras_rcnn/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import keras
-import keras_resnet
+import keras_resnet.models
 
 import keras_rcnn.layers
 import keras_rcnn.classifiers
@@ -12,7 +12,7 @@ class RCNN(keras.models.Model):
     Faster R-CNN model by S Ren et, al. (2015).
 
     :param inputs: input tensor (e.g. an instance of `keras.layers.Input`)
-    :param encoder: (Convolutional) feature extractor, e.g., `keras_resnet.ResNet50`
+    :param encoder: (Convolutional) feature extractor, e.g., `keras_resnet.models.ResNet50`
     :param heads: R-CNN classifiers for object detection and/or segmentation on the proposed regions
     :param rois: integer, number of regions of interest per image
 
@@ -55,7 +55,7 @@ class ResNet50RCNN(RCNN):
 
     def __init__(self, inputs, classes, rois=300):
         # ResNet50 as encoder
-        encoder = keras_resnet.ResNet50
+        encoder = keras_resnet.models.ResNet50
 
         # ResHead with score and boxes
         heads = keras_rcnn.classifiers.residual(classes)


### PR DESCRIPTION
Not sure if this (PR) is the best way to show what I had in mind, but lets give it a shot :)

This PR is mainly intended to show how I more or less had implemented RPN losses in my own port. I'm guessing the losses don't make sense at the moment, they are *only there to convey the idea*. Mathematically they probably make no sense at the moment because I believe it receives different inputs.

Also I changed the ResNet classifier according to the changes in https://github.com/broadinstitute/keras-resnet/pull/24, I'm not sure if the existing ResNet classifier in `keras-rcnn` was correct.

Also, the RPN layers appeared to miss an initial convolutional layer, called `rpn_conv_3x3` in the Caffe prototxts. In addition, the convolutional layer for rpn class scores gave as output `num_anchors`, but it should give `num_anchors * 2`, since it classifies two classes (fg/bg).

These are the main contributions in this PR, aside from some minor corrections here and there.

I would gladly hear what you think @0x00b1 . Maybe we can discuss this further tomorrow, on Slack?