### PR TITLE
Change rpn classification loss layer.

### DIFF
--- a/keras_rcnn/layers/__init__.py
+++ b/keras_rcnn/layers/__init__.py
@@ -1,7 +1,7 @@
-from .losses import Classification, Regression
+from .losses import ClassificationLoss, RegressionLoss
 
-from .object_detection import (ObjectProposal)
+from .object_detection import ObjectProposal
 
-from .object_detection import (ProposalTarget)
+from .object_detection import ProposalTarget
 
 from .pooling import ROI

--- a/keras_rcnn/models.py
+++ b/keras_rcnn/models.py
@@ -33,12 +33,15 @@ class RCNN(keras.models.Model):
         proposals                        = keras_rcnn.layers.ObjectProposal(maximum_proposals=rois)([im_info, rpn_regression, rpn_classification])
         rpn_labels, rpn_bbox_reg_targets = keras_rcnn.layers.ProposalTarget()([gt_boxes, im_info])
 
+        rpn_classification_loss = keras_rcnn.layers.ClassificationLoss(anchors=num_anchors, name="rpn_classification_loss")([rpn_labels, rpn_classification])
+        #rpn_regression_loss     = keras_rcnn.layers.RegressionLoss(name="rpn_bbox_loss")([rpn_bbox_reg_targets, rpn_regression])
+
         # Apply the classifiers on the proposed regions
         slices = keras_rcnn.layers.ROI((7, 7))([image, proposals])
 
         [score, boxes] = heads(slices)
 
-        super(RCNN, self).__init__(inputs, [rpn_prediction, score, boxes, rpn_labels, rpn_bbox_reg_targets])
+        super(RCNN, self).__init__(inputs, [rpn_prediction, score, boxes, rpn_classification_loss])
 
 
 class ResNet50RCNN(RCNN):


### PR DESCRIPTION
As mentioned [here](https://github.com/broadinstitute/keras-rcnn/pull/41#discussion_r131342299), this is what I propose. I have not tested this, so I don't know if it is working or not. This PR only changes the classification loss, I didn't touch the regression loss.

Basically what this does is:

1. Reshape predicted classifications to `(None, 2)` (`rpn_labels` is already `(None,)`.
2. Select those classifications that have a label which is not equal to `-1`. These are labelled as background (`0`) or foreground (`1`). `-1` is reserved for "don't care".
3. Similarly, filter out `rpn_labels` with `-1`.
4. Execute `categorical_crossentropy` on the resulting two tensors (`rpn_labels.shape = (None,)` and `rpn_classification.shape = (None, 2)`).

I would love to hear some feedback on this approach of RPN losses.