### PR TITLE
Bug fix to bounding box generator

### DIFF
--- a/keras_rcnn/preprocessing/_object_detection.py
+++ b/keras_rcnn/preprocessing/_object_detection.py
@@ -89,7 +89,7 @@ class DictionaryIterator(Iterator):
         ds = self.dictionary[index]["boxes"]
 
         boxes = numpy.asarray(
-            [[d[k] for k in ['x1','x2','y1','y2']] for d in ds])
+            [[d[k] for k in ['y1','x1','y2','x2']] for d in ds])
         klass = numpy.asarray([d['class'] for d in ds])
 
         boxes = numpy.expand_dims(boxes, 0)

--- a/keras_rcnn/preprocessing/_object_detection.py
+++ b/keras_rcnn/preprocessing/_object_detection.py
@@ -89,9 +89,8 @@ class DictionaryIterator(Iterator):
         ds = self.dictionary[index]["boxes"]
 
         boxes = numpy.asarray(
-            [[d[k] for i, k in enumerate(d) if i > 0] for d in ds])
-        klass = numpy.asarray(
-            [[d[k] for i, k in enumerate(d) if i < 1] for d in ds])
+            [[d[k] for k in ['x1','x2','y1','y2']] for d in ds])
+        klass = numpy.asarray([d['class'] for d in ds])
 
         boxes = numpy.expand_dims(boxes, 0)
 


### PR DESCRIPTION
Small fix in the object detection generator. `ds` is a list of dicts, for example: `[{u'x2': 151, u'y1': 299, u'x1': 34, u'y2': 422, u'class': u'rbc'}, ...]`

`enumerate(d)` has no guarantee on the order if `d` is a dict, so `[d[k] for i, k in enumerate(d) if i > 0]` can return any 4 of the keys in the dict.
In my case it looked like this before the fix:

```
(Pdb) boxes
array([[u'299', u'34', u'422', u'rbc'],
       [u'459', u'718', u'573', u'rbc'],
       [u'235', u'629', u'343', u'rbc'],
       [u'1024', u'888', u'1137', u'rbc'],
       [u'288', u'907', u'392', u'rbc'],
       [u'963', u'637', u'1082', u'rbc'], (truncated)
```

After:

```
(Pdb) boxes
array([[ 660,  757,  998, 1091],
       [ 706,  807,  147,  244],
       [ 755,  867,  749,  862],
       [ 486,  607,  232,  363],
       [1073, 1188,  145,  248],
       [ 865,  970,  270,  371], (truncated)
```

This `['y1','x1','y2','x2']` is the order specified in tensorflow.non_maximum_suppression ('Bounding boxes are supplied as [y1, x1, y2, x2]'), but I'm not 100% sure it's what we want to use here.