### PR TITLE
bug fixes to the rpn - be careful to keep the zeroth axis for the batch

### DIFF
--- a/keras_rcnn/layers/losses.py
+++ b/keras_rcnn/layers/losses.py
@@ -20,7 +20,7 @@ class ClassificationLoss(keras.layers.Layer):
 
     @staticmethod
     def compute_loss(output, target):
-        output = keras.backend.reshape(output, [-1, 2])
+        output = keras.backend.reshape(output, [1, -1, 2])
 
         condition = keras.backend.not_equal(target, -1)
 


### PR DESCRIPTION
Some fixes for the RPN. 
- It's important to keep the zeroth axis for the number of samples in the batch, or keras will have many issues. This was not the case in the current code.
- Updated `_anchor_target` to use `metadata` as the input instead of using `int_shape` on the image. Should make things easier.