### PR TITLE
Anchor target update

### DIFF
--- a/keras_rcnn/layers/object_detection/_anchor_target.py
+++ b/keras_rcnn/layers/object_detection/_anchor_target.py
@@ -41,7 +41,7 @@ class AnchorTarget(keras.layers.Layer):
     def call(self, inputs, **kwargs):
         scores, gt_boxes, metadata = inputs
 
-        metadata = metadata[0,:]
+        metadata = metadata[0, :]
 
         gt_boxes = gt_boxes[0]
 
@@ -49,7 +49,7 @@ class AnchorTarget(keras.layers.Layer):
         cc = keras.backend.shape(scores)[2]
 
         # 1. Generate proposals from bbox deltas and shifted anchors
-        anchors = keras_rcnn.backend.shift((rr, cc), self.stride)       
+        anchors = keras_rcnn.backend.shift((rr, cc), self.stride)
 
         # 2. obtain indices of gt boxes with the greatest overlap, balanced labels
         argmax_overlaps_indices, labels = label(gt_boxes, anchors, self.negative_overlap, self.positive_overlap, self.clobber_positives)
@@ -59,14 +59,14 @@ class AnchorTarget(keras.layers.Layer):
         # Convert fixed anchors in (x, y, w, h) to (dx, dy, dw, dh)
         bbox_reg_targets = keras_rcnn.backend.bbox_transform(anchors, gt_boxes)
 
-        # reshape to (num_boxes, 4) 
+        # reshape to (num_boxes, 4)
         bbox_reg_targets = keras.backend.reshape(bbox_reg_targets, (-1, 4))
-        
+
         # only keep anchors inside the image
         inds_inside = inside_image(anchors, metadata, self.allowed_border)
         labels = keras_rcnn.backend.where(inds_inside, labels, -1 * tensorflow.ones_like(labels))
 
-        # expand the 0th axis as keras requires that exis for batch samples        
+        # expand the 0th axis as keras requires that exis for batch samples
         labels = keras.backend.expand_dims(labels, axis=0)
         bbox_reg_targets = keras.backend.expand_dims(bbox_reg_targets, axis=0)
 
@@ -109,9 +109,9 @@ def label(y_true, y_pred, RPN_NEGATIVE_OVERLAP=0.3, RPN_POSITIVE_OVERLAP=0.7, cl
     :return: indices of gt boxes with the greatest overlap, balanced labels
     """
 
-    ones = keras.backend.ones_like(y_pred[:,:1], dtype=keras.backend.floatx())
+    ones = keras.backend.ones_like(y_pred[:, :1], dtype=keras.backend.floatx())
     labels = ones * -1
-    zeros = keras.backend.zeros_like(y_pred[:,:1], dtype=keras.backend.floatx())
+    zeros = keras.backend.zeros_like(y_pred[:, :1], dtype=keras.backend.floatx())
 
     argmax_overlaps_inds, max_overlaps, gt_argmax_overlaps_inds = overlapping(y_pred, y_true)
 
@@ -125,7 +125,7 @@ def label(y_true, y_pred, RPN_NEGATIVE_OVERLAP=0.3, RPN_POSITIVE_OVERLAP=0.7, cl
     unique_indices, unique_indices_indices = keras_rcnn.backend.unique(gt_argmax_overlaps_inds, return_index=True)
     inverse_labels = keras.backend.gather(-1 * labels, unique_indices)
     unique_indices = keras.backend.expand_dims(unique_indices, 1)
-    updates = keras.backend.ones_like(keras.backend.reshape(unique_indices, (-1,1)), dtype=keras.backend.floatx())
+    updates = keras.backend.ones_like(keras.backend.reshape(unique_indices, (-1, 1)), dtype=keras.backend.floatx())
 
     #return labels, unique_indices, inverse_labels, updates
     labels = keras_rcnn.backend.scatter_add_tensor(labels, unique_indices, inverse_labels + updates)
@@ -135,9 +135,9 @@ def label(y_true, y_pred, RPN_NEGATIVE_OVERLAP=0.3, RPN_POSITIVE_OVERLAP=0.7, cl
     if clobber_positives:
         # assign bg labels last so that negative labels can clobber positives
         labels = keras_rcnn.backend.where(keras.backend.less(max_overlaps, RPN_NEGATIVE_OVERLAP), zeros, labels)
-    
+
     labels = keras.backend.reshape(labels, (-1,))
-    
+
     return argmax_overlaps_inds, balance(labels)
 
 
@@ -233,7 +233,6 @@ def subsample_positive_labels(labels):
     return keras.backend.switch(condition, labels, lambda: more_positive())
 
 
-
 def inside_image(boxes, im_info, allowed_border=0):
     """
     Calc indices of boxes which are located completely inside of the image
@@ -249,8 +248,8 @@ def inside_image(boxes, im_info, allowed_border=0):
     indices = (
         (boxes[:, 0] >= -allowed_border) &
         (boxes[:, 1] >= -allowed_border) &
-        (boxes[:, 2] < allowed_border + im_info[1]) & # width
-        (boxes[:, 3] < allowed_border + im_info[0])   # height
+        (boxes[:, 2] < allowed_border + im_info[1]) &  # width
+        (boxes[:, 3] < allowed_border + im_info[0])    # height
     )
 
     return indices

--- a/tests/layers/object_detection/test_anchor_target.py
+++ b/tests/layers/object_detection/test_anchor_target.py
@@ -22,6 +22,8 @@ import keras_rcnn.layers.object_detection._anchor_target
 def test_label():
     stride = 16
     feat_h, feat_w = (14, 14)
+    num_default_anchors = 9
+
     img_info = keras.backend.variable([[224, 224, 3]])
 
     gt_boxes = keras.backend.variable(100 * numpy.random.random((91, 4)))
@@ -29,29 +31,30 @@ def test_label():
 
     all_bbox = keras_rcnn.backend.shift((feat_h, feat_w), stride)
 
-    inds_inside, all_inside_bbox = keras_rcnn.layers.object_detection._anchor_target.inside_image(all_bbox, img_info[0])
+    inds_inside = keras_rcnn.layers.object_detection._anchor_target.inside_image(all_bbox, img_info[0])
 
-    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_inside_bbox, inds_inside)
+    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_bbox)
 
     result1 = keras.backend.eval(argmax_overlaps_inds)
+
     result2 = keras.backend.eval(bbox_labels)
 
-    assert result1.shape == (84,)
+    assert result1.shape == (feat_h * feat_w * num_default_anchors,)
 
-    assert result2.shape == (84,)
+    assert result2.shape == (feat_h * feat_w * num_default_anchors,)
 
     assert numpy.max(result2) <= 1
 
     assert numpy.min(result2) >= -1
 
-    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_inside_bbox, inds_inside, clobber_positives=False)
+    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_bbox, clobber_positives=False)
 
     result1 = keras.backend.eval(argmax_overlaps_inds)
     result2 = keras.backend.eval(bbox_labels)
 
-    assert result1.shape == (84,)
+    assert result1.shape == (feat_h * feat_w * num_default_anchors,)
 
-    assert result2.shape == (84,)
+    assert result2.shape == (feat_h * feat_w * num_default_anchors,)
 
     assert numpy.max(result2) <= 1
 
@@ -59,13 +62,13 @@ def test_label():
 
     gt_boxes = keras.backend.variable(224 * numpy.random.random((55, 4)))
     gt_boxes = tensorflow.convert_to_tensor(gt_boxes, dtype=tensorflow.float32)
-    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_inside_bbox, inds_inside, clobber_positives=False)
+    argmax_overlaps_inds, bbox_labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_bbox, clobber_positives=False)
     result1 = keras.backend.eval(argmax_overlaps_inds)
     result2 = keras.backend.eval(bbox_labels)
 
-    assert result1.shape == (84,)
+    assert result1.shape == (feat_h * feat_w * num_default_anchors,)
 
-    assert result2.shape == (84,)
+    assert result2.shape == (feat_h * feat_w * num_default_anchors,)
 
     assert numpy.max(result2) <= 1
 
@@ -139,63 +142,38 @@ def test_overlapping():
     gt_boxes = numpy.zeros((91, 4))
     gt_boxes = keras.backend.variable(gt_boxes)
     img_info = img_info[0]
+    num_default_anchors = 9
 
     all_anchors = keras_rcnn.backend.shift(features, stride)
 
-    inds_inside, all_inside_anchors = keras_rcnn.layers.object_detection._anchor_target.inside_image(
-        all_anchors, img_info)
-
     argmax_overlaps_inds, max_overlaps, gt_argmax_overlaps_inds = keras_rcnn.layers.object_detection._anchor_target.overlapping(
-        all_inside_anchors, gt_boxes, inds_inside)
+        all_anchors, gt_boxes)
 
     argmax_overlaps_inds = keras.backend.eval(argmax_overlaps_inds)
     max_overlaps = keras.backend.eval(max_overlaps)
     gt_argmax_overlaps_inds = keras.backend.eval(gt_argmax_overlaps_inds)
 
-    assert argmax_overlaps_inds.shape == (84,)
+    num_anchors = features[0] * features[1] * num_default_anchors
 
-    assert max_overlaps.shape == (84,)
+    assert argmax_overlaps_inds.shape == (num_anchors,)
 
-    assert gt_argmax_overlaps_inds.shape == (91,)
+    assert max_overlaps.shape == (num_anchors,)
 
-
-def test_unmap():
-    stride = 16
-    features = (14, 14)
-    anchors = 9
-    total_anchors = features[0]*features[1]*anchors
-    img_info = keras.backend.variable([[224, 224, 3]])
-    gt_boxes = numpy.zeros((91, 4))
-    gt_boxes = keras.backend.variable(gt_boxes)
-
-    all_anchors = keras_rcnn.backend.shift(features, stride)
-
-    inds_inside, all_inside_anchors = keras_rcnn.layers.object_detection._anchor_target.inside_image(all_anchors, img_info[0])
-
-    argmax_overlaps_indices, labels = keras_rcnn.layers.object_detection._anchor_target.label(gt_boxes, all_inside_anchors, inds_inside)
-    bbox_reg_targets = keras_rcnn.backend.bbox_transform(all_inside_anchors, keras.backend.gather(gt_boxes, argmax_overlaps_indices))
-
-    labels = keras_rcnn.layers.object_detection._anchor_target.unmap(labels, total_anchors, inds_inside, fill=-1)
-    bbox_reg_targets = keras_rcnn.layers.object_detection._anchor_target.unmap(bbox_reg_targets, total_anchors, inds_inside, fill=0)
-
-    assert keras.backend.eval(labels).shape == (total_anchors, )
-    assert keras.backend.eval(bbox_reg_targets).shape == (total_anchors, 4)
+    assert gt_argmax_overlaps_inds.shape == (gt_boxes.shape[0],)
 
 
 def test_inside_image():
     stride = 16
     features = (14, 14)
+    num_default_anchors = 9
 
     all_anchors = keras_rcnn.backend.shift(features, stride)
 
     img_info = (224, 224, 1)
 
-    inds_inside, all_inside_anchors = keras_rcnn.layers.object_detection._anchor_target.inside_image(all_anchors, img_info)
-
+    inds_inside = keras_rcnn.layers.object_detection._anchor_target.inside_image(all_anchors, img_info)
     inds_inside = keras.backend.eval(inds_inside)
 
-    assert inds_inside.shape == (84,)
-
-    all_inside_anchors = keras.backend.eval(all_inside_anchors)
-
-    assert all_inside_anchors.shape == (84, 4)
+    assert inds_inside.dtype == numpy.dtype('bool')
+    assert inds_inside.shape == (features[0] * features[1] * num_default_anchors,)
+    assert numpy.sum(inds_inside.astype(numpy.int32)) == 84


### PR DESCRIPTION
This updates the `AnchorTarget()` layer to function with inputs of size `(None, None, num_channels)`.

- The `unmap()` function has been completely removed. Instead, anchors outside the image are retained when calculating overlaps, then their labels are overwritten afterwards.
- The signature of the `label` and `overlapping` functions are now consequently simpler. For example, `overlapping(anchors, gt_boxes, inds_inside)` is now simply `def overlapping(anchors, gt_boxes)`, which is a lot more intuitive.
- Calls to `keras.backend.int_shape` are gone, so no more errors when input sizes are None.
- I've updated the tests. Lets hope they pass!
A sample gist is here: https://gist.github.com/yhenon/54cf15f0955c8e90d42c15244d7e0f42
 