### PR TITLE
Correct use of shape in anchor generation.

### DIFF
--- a/keras_rcnn/backend/common.py
+++ b/keras_rcnn/backend/common.py
@@ -144,8 +144,8 @@ def shift(shape, stride):
     """
     Produce shifted anchors based on shape of the map and stride size
     """
-    shift_x = keras.backend.arange(0, shape[0]) * stride
-    shift_y = keras.backend.arange(0, shape[1]) * stride
+    shift_x = keras.backend.arange(0, shape[1]) * stride
+    shift_y = keras.backend.arange(0, shape[0]) * stride
 
     shift_x, shift_y = keras_rcnn.backend.meshgrid(shift_x, shift_y)
     shift_x = keras.backend.reshape(shift_x, [-1])


### PR DESCRIPTION
The [input](https://github.com/broadinstitute/keras-rcnn/blob/master/keras_rcnn/layers/object_detection/_anchor_target.py#L73) is `(rr, cc)` so the usage of shape in `shift()` was incorrect.