### PR TITLE
Fix tensorflow backend tests

### DIFF
--- a/keras_rcnn/backend/tensorflow_backend.py
+++ b/keras_rcnn/backend/tensorflow_backend.py
@@ -140,7 +140,7 @@ def crop_and_resize(image, boxes, size):
     box_ind = box_ind[:, 0]
     box_ind = keras.backend.reshape(box_ind, [-1])
 
-    boxes = keras.backend.reshape(boxes, [-1, 4])
+    boxes = keras.backend.cast(keras.backend.reshape(boxes, [-1, 4]),'float32')
 
     return tensorflow.image.crop_and_resize(image, boxes, box_ind, size)
 

--- a/tests/backend/test_common.py
+++ b/tests/backend/test_common.py
@@ -161,8 +161,7 @@ def test_scale_enum():
     expected = numpy.array(
         [[0, 0, 0, 0], [-0.5, -0.5, 0.5, 0.5], [-1., -1., 1., 1.]])
     numpy.testing.assert_array_equal(results, expected)
-    anchor = keras.backend.cast(
-        numpy.expand_dims(numpy.array([2, 3, 100, 100]), 0), 'float32')
+    anchor = numpy.expand_dims(numpy.array([2, 3, 100, 100]), 0)
     anchor = keras.backend.variable(anchor)
     results = keras_rcnn.backend.common._scale_enum(anchor, scales)
     results = keras.backend.eval(results)


### PR DESCRIPTION
The two commits try to fix #159 and also part of #158.

As described in the commit descriptions, I am not sure if the typecast was there on purpose and it made problems. Removing it does not seem to break the tests at least on my system.