### PR TITLE
fixed ObjectDetection call() input inconsistencies

### DIFF
--- a/keras_rcnn/layers/_object_detection.py
+++ b/keras_rcnn/layers/_object_detection.py
@@ -32,9 +32,9 @@ class ObjectDetection(keras.engine.topology.Layer):
         other classes
         """
 
-        def detections(num_output):
-            metadata, deltas, proposals, scores = x[0], x[1], x[2], x[3]
+        metadata, deltas, proposals, scores = x[0], x[1], x[2], x[3]
 
+        def detections(num_output):
             proposals = keras.backend.reshape(proposals, (-1, 4))
 
             # unscale back to raw image space
@@ -84,9 +84,9 @@ class ObjectDetection(keras.engine.topology.Layer):
 
             return detections[num_output]
 
-        bounding_boxes = keras.backend.in_train_phase(x[2], lambda: detections(0), training=training)
+        bounding_boxes = keras.backend.in_train_phase(proposals, lambda: detections(0), training=training)
 
-        scores = keras.backend.in_train_phase(x[3], lambda: detections(1), training=training)
+        scores = keras.backend.in_train_phase(scores, lambda: detections(1), training=training)
 
         return [bounding_boxes, scores]
 

--- a/keras_rcnn/layers/_object_detection.py
+++ b/keras_rcnn/layers/_object_detection.py
@@ -19,13 +19,12 @@ class ObjectDetection(keras.engine.topology.Layer):
     def call(self, x, training=None, **kwargs):
         """
         # Inputs
-        proposals: output of proposal target (1, N, 4)
-        deltas: predicted deltas (1, N, 4*classes)
-        scores: score distributions (1, N, classes)
         metadata: image information (1, 3)
-
+        deltas: predicted deltas (1, N, 4*classes)
+        proposals: output of proposal target (1, N, 4)
+        scores: score distributions (1, N, classes)
+        
         # Returns
-
         bounding_boxes: predicted boxes (1, N, 4 * classes)
 
         scores: score distribution over all classes (1, N, classes),
@@ -85,9 +84,9 @@ class ObjectDetection(keras.engine.topology.Layer):
 
             return detections[num_output]
 
-        bounding_boxes = keras.backend.in_train_phase(x[0], lambda: detections(0), training=training)
+        bounding_boxes = keras.backend.in_train_phase(x[2], lambda: detections(0), training=training)
 
-        scores = keras.backend.in_train_phase(x[2], lambda: detections(1), training=training)
+        scores = keras.backend.in_train_phase(x[3], lambda: detections(1), training=training)
 
         return [bounding_boxes, scores]
 

--- a/keras_rcnn/preprocessing/_object_detection.py
+++ b/keras_rcnn/preprocessing/_object_detection.py
@@ -175,7 +175,7 @@ class DictionaryIterator(keras.preprocessing.image.Iterator):
             )
 
             for bounding_box_index, bounding_box in enumerate(bounding_boxes):
-                if bounding_box["class"] not in self.categories:
+                if bounding_box["category"] not in self.categories:
                     continue
 
                 minimum_r = bounding_box["bounding_box"]["minimum"]["r"]
@@ -243,7 +243,7 @@ class DictionaryIterator(keras.preprocessing.image.Iterator):
 
                 target_category = numpy.zeros((self.n_categories))
 
-                target_category[self.categories[bounding_box["class"]]] = 1
+                target_category[self.categories[bounding_box["category"]]] = 1
 
                 target_categories[
                     batch_index,


### PR DESCRIPTION
Changes made to fix inconsistencies caused by rearranging the expected inputs to call(), as reviewed by @jorgeecardona in [#164](https://github.com/broadinstitute/keras-rcnn/pull/164).

Moved the input definitions outside detections() so that they can be used to define bounding_boxes and scores more explicitly.